### PR TITLE
feat: add esp32c3 supermini project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 jsconfig.json
 node_modules
+esp-idf/

--- a/esp32c3_supermini/CMakeLists.txt
+++ b/esp32c3_supermini/CMakeLists.txt
@@ -1,0 +1,3 @@
+cmake_minimum_required(VERSION 3.16)
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(supermini_control)

--- a/esp32c3_supermini/README.md
+++ b/esp32c3_supermini/README.md
@@ -1,0 +1,20 @@
+# ESP32-C3 Supermini Dual Display Controller
+
+This example project targets the **ESP32-C3 Supermini** and demonstrates how to:
+
+- Drive two GC9A01 circular displays using the [`espressif/esp_lcd_gc9a01`](https://components.espressif.com/components/espressif/esp_lcd_gc9a01) component.
+- Read two rotary encoders: one to select which parameter is active and one to modify the value of the selected parameter.
+
+The code keeps an array of parameters (altitude, speed and time) and updates the screens and serial log accordingly.
+
+## Building
+
+The project uses the local copy of ESP-IDF contained in this repository.  After installing the ESP-IDF tools, build with:
+
+```bash
+cd esp32c3_supermini
+. ../esp-idf/export.sh
+idf.py build
+```
+
+Adjust the GPIO pin assignments in `main.c` to match your hardware wiring.

--- a/esp32c3_supermini/main/CMakeLists.txt
+++ b/esp32c3_supermini/main/CMakeLists.txt
@@ -1,0 +1,1 @@
+idf_component_register(SRCS "main.c" "rotary_encoder.c" INCLUDE_DIRS ".")

--- a/esp32c3_supermini/main/idf_component.yml
+++ b/esp32c3_supermini/main/idf_component.yml
@@ -1,0 +1,2 @@
+dependencies:
+  espressif/esp_lcd_gc9a01: "*"

--- a/esp32c3_supermini/main/main.c
+++ b/esp32c3_supermini/main/main.c
@@ -1,0 +1,106 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "esp_system.h"
+#include "driver/spi_master.h"
+#include "esp_lcd_panel_ops.h"
+#include "esp_lcd_panel_vendor.h"
+#include "esp_lcd_gc9a01.h"
+#include "rotary_encoder.h"
+
+#define TAG "SUPERMINI"
+
+// SPI pins (adjust to match your hardware)
+#define PIN_NUM_MOSI 6
+#define PIN_NUM_CLK 4
+#define PIN_NUM_CS_NAV 5
+#define PIN_NUM_CS_VAL 7
+#define PIN_NUM_DC 2
+#define PIN_NUM_RST 1
+
+// Rotary encoder pins
+#define ENC_NAV_A GPIO_NUM_8
+#define ENC_NAV_B GPIO_NUM_9
+#define ENC_VAL_A GPIO_NUM_10
+#define ENC_VAL_B GPIO_NUM_18
+
+static esp_lcd_panel_handle_t nav_panel;
+static esp_lcd_panel_handle_t value_panel;
+static rotary_encoder_t nav_encoder;
+static rotary_encoder_t value_encoder;
+
+static void init_display(esp_lcd_panel_handle_t *panel, int cs)
+{
+    static bool bus_initialized = false;
+    spi_bus_config_t buscfg = {
+        .sclk_io_num = PIN_NUM_CLK,
+        .mosi_io_num = PIN_NUM_MOSI,
+        .miso_io_num = -1,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+        .max_transfer_sz = 240 * 240 * 2,
+    };
+    if (!bus_initialized) {
+        ESP_ERROR_CHECK(spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO));
+        bus_initialized = true;
+    }
+    esp_lcd_panel_io_spi_config_t io_config = {
+        .dc_gpio_num = PIN_NUM_DC,
+        .cs_gpio_num = cs,
+        .pclk_hz = 40 * 1000 * 1000,
+        .lcd_cmd_bits = 8,
+        .lcd_param_bits = 8,
+        .spi_mode = 0,
+        .trans_queue_depth = 10,
+    };
+    esp_lcd_panel_io_handle_t io_handle;
+    ESP_ERROR_CHECK(esp_lcd_new_panel_io_spi((spi_bus_handle_t)SPI2_HOST, &io_config, &io_handle));
+
+    esp_lcd_panel_dev_config_t panel_config = {
+        .reset_gpio_num = PIN_NUM_RST,
+        .rgb_ele_order = LCD_RGB_ELEMENT_ORDER_RGB,
+        .bits_per_pixel = 16,
+    };
+    ESP_ERROR_CHECK(esp_lcd_new_panel_gc9a01(io_handle, &panel_config, panel));
+    ESP_ERROR_CHECK(esp_lcd_panel_reset(*panel));
+    ESP_ERROR_CHECK(esp_lcd_panel_init(*panel));
+    ESP_ERROR_CHECK(esp_lcd_panel_disp_off(*panel, false));
+}
+
+static void fill_color(esp_lcd_panel_handle_t panel, uint16_t color)
+{
+    uint16_t line[240];
+    for (int x = 0; x < 240; ++x) {
+        line[x] = color;
+    }
+    for (int y = 0; y < 240; ++y) {
+        esp_lcd_panel_draw_bitmap(panel, 0, y, 240, y + 1, line);
+    }
+}
+
+void app_main(void)
+{
+    init_display(&nav_panel, PIN_NUM_CS_NAV);
+    init_display(&value_panel, PIN_NUM_CS_VAL);
+    rotary_encoder_init(&nav_encoder, ENC_NAV_A, ENC_NAV_B);
+    rotary_encoder_init(&value_encoder, ENC_VAL_A, ENC_VAL_B);
+
+    const char *params[] = {"ALTITUDE", "SPEED", "TIME"};
+    int values[3] = {0};
+    int current = 0;
+
+    while (1) {
+        int nav_pos = rotary_encoder_get_count(&nav_encoder);
+        current = (nav_pos % 3 + 3) % 3; // ensure positive index
+
+        int val_pos = rotary_encoder_get_count(&value_encoder);
+        values[current] = val_pos;
+
+        ESP_LOGI(TAG, "Param %s = %d", params[current], values[current]);
+
+        fill_color(nav_panel, 0xFFFF - current * 0x1000);
+        fill_color(value_panel, 0x001F + values[current]);
+
+        vTaskDelay(pdMS_TO_TICKS(200));
+    }
+}

--- a/esp32c3_supermini/main/rotary_encoder.c
+++ b/esp32c3_supermini/main/rotary_encoder.c
@@ -1,0 +1,50 @@
+#include "rotary_encoder.h"
+
+esp_err_t rotary_encoder_init(rotary_encoder_t *enc, gpio_num_t pin_a, gpio_num_t pin_b)
+{
+    pcnt_unit_config_t unit_config = {
+        .low_limit = -1000,
+        .high_limit = 1000,
+    };
+    ESP_ERROR_CHECK(pcnt_new_unit(&unit_config, &enc->unit));
+
+    pcnt_chan_config_t chan_a_config = {
+        .edge_gpio_num = pin_a,
+        .level_gpio_num = pin_b,
+    };
+    pcnt_channel_handle_t chan_a;
+    ESP_ERROR_CHECK(pcnt_new_channel(enc->unit, &chan_a_config, &chan_a));
+
+    pcnt_chan_config_t chan_b_config = {
+        .edge_gpio_num = pin_b,
+        .level_gpio_num = pin_a,
+    };
+    pcnt_channel_handle_t chan_b;
+    ESP_ERROR_CHECK(pcnt_new_channel(enc->unit, &chan_b_config, &chan_b));
+
+    ESP_ERROR_CHECK(pcnt_channel_set_edge_action(chan_a, PCNT_CHANNEL_EDGE_ACTION_DECREASE,
+                                                 PCNT_CHANNEL_EDGE_ACTION_INCREASE));
+    ESP_ERROR_CHECK(pcnt_channel_set_level_action(chan_a, PCNT_CHANNEL_LEVEL_ACTION_KEEP,
+                                                  PCNT_CHANNEL_LEVEL_ACTION_INVERSE));
+    ESP_ERROR_CHECK(pcnt_channel_set_edge_action(chan_b, PCNT_CHANNEL_EDGE_ACTION_INCREASE,
+                                                 PCNT_CHANNEL_EDGE_ACTION_DECREASE));
+    ESP_ERROR_CHECK(pcnt_channel_set_level_action(chan_b, PCNT_CHANNEL_LEVEL_ACTION_KEEP,
+                                                  PCNT_CHANNEL_LEVEL_ACTION_INVERSE));
+
+    ESP_ERROR_CHECK(pcnt_unit_enable(enc->unit));
+    ESP_ERROR_CHECK(pcnt_unit_clear_count(enc->unit));
+    ESP_ERROR_CHECK(pcnt_unit_start(enc->unit));
+    return ESP_OK;
+}
+
+int rotary_encoder_get_count(rotary_encoder_t *enc)
+{
+    int val = 0;
+    pcnt_unit_get_count(enc->unit, &val);
+    return val;
+}
+
+void rotary_encoder_reset(rotary_encoder_t *enc)
+{
+    pcnt_unit_clear_count(enc->unit);
+}

--- a/esp32c3_supermini/main/rotary_encoder.h
+++ b/esp32c3_supermini/main/rotary_encoder.h
@@ -1,0 +1,12 @@
+#pragma once
+#include "driver/gpio.h"
+#include "driver/pulse_cnt.h"
+#include "esp_err.h"
+
+typedef struct {
+    pcnt_unit_handle_t unit;
+} rotary_encoder_t;
+
+esp_err_t rotary_encoder_init(rotary_encoder_t *enc, gpio_num_t pin_a, gpio_num_t pin_b);
+int rotary_encoder_get_count(rotary_encoder_t *enc);
+void rotary_encoder_reset(rotary_encoder_t *enc);


### PR DESCRIPTION
## Summary
- add ESP-IDF project for ESP32-C3 Supermini with two GC9A01 LCDs and two rotary encoders
- include rotary encoder helper, project CMake setup and README

## Testing
- `../esp-idf/install.sh esp32c3`
- `idf.py build` *(fails: Cannot establish a connection to the component registry)*

------
https://chatgpt.com/codex/tasks/task_e_689f35e18b48832bb2c2280a1e52d455